### PR TITLE
Update Makefile

### DIFF
--- a/src/tests/Makefile
+++ b/src/tests/Makefile
@@ -1,5 +1,5 @@
 CC=gcc
-LDLIBS=`pkg-config --libs sqlite3` ../bitcloud.a
+LDLIBS=../bitcloud.a `pkg-config --libs sqlite3`
 INCLUDES=-I..
 CFLAGS=-Wall -ansi `pkg-config --cflags sqlite3`
 


### PR DESCRIPTION
../bitcloud.a should be included before `pkg-config --libs sqlite3`, my system (gcc ubuntu 13.10) otherwise gives me a 'undefined reference' error
